### PR TITLE
Fix createGEP() to create index constants.

### DIFF
--- a/R/IRBuilder.R
+++ b/R/IRBuilder.R
@@ -166,8 +166,13 @@ function(builder, val, isVolatile = FALSE, id = character())
 createGEP =
 function(builder, val, index, id = character())
 {
-  if(isBasicType(index))
-     index = makeConstant(builder, index)
+  if (!is.list(index)) index = as.list(index)
+
+  index =
+    lapply(index, function(idx) {
+      if (isBasicType(idx)) makeConstant(builder, idx)
+      else idx
+    })
 
   .Call("R_IRBuilder_CreateGEP", builder, val, index, as.character(id))
 }


### PR DESCRIPTION
GEP instructions often take multiple indexes, but the existing `createGEP()` function doesn't automatically make constants for lists or vectors of indexes.

This patch fixes `createGEP()` to automatically make constants for lists or vectors of indexes.