### PR TITLE
Remove duplicate createPHI and fix arg name typo.

### DIFF
--- a/R/IRBuilder.R
+++ b/R/IRBuilder.R
@@ -532,8 +532,8 @@ function(builder, value, type, id = "")
 
 
 
-createPhi = createPHI =
-function(build, type, numReservedValues, id = character())
+createPhi =
+function(builder, type, numReservedValues, id = character())
 {
   .Call("R_IRBuilder_CreatePHI", as(builder, "IRBuilder"), as(type, "Type"), as.integer(numReservedValues), as.character(id))
 }


### PR DESCRIPTION
This makes the `createPhi` function usable.

I'm not sure why `createPhi` and `createPHI` were both defined. RLLVMCompile does not use either, so AFAIK we can safely remove one.